### PR TITLE
added encoding="utf-8", because sometimes it may fail to load because of EMOJIS

### DIFF
--- a/notebooks/2_BytePairEncoding.ipynb
+++ b/notebooks/2_BytePairEncoding.ipynb
@@ -13,7 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(\"../output/combined_text.txt\", \"r\") as f:\n",
+    "with open(\"../output/combined_text.txt\", \"r\", encoding=\"utf-8\") as f:\n",
     "    text_sequence = f.read()\n",
     "\n",
     "len(text_sequence)"


### PR DESCRIPTION
added encoding="utf-8", because sometimes it may fail to load because of EMOJIS in dataset