### PR TITLE
Fix: Add explicit utf-8 encoding to file open

### DIFF
--- a/notebooks/4_1_ModelTrainingAllBatches.ipynb
+++ b/notebooks/4_1_ModelTrainingAllBatches.ipynb
@@ -115,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(\"../output/combined_text.txt\", \"r\") as f:\n",
+    "with open(\"../output/combined_text.txt\", \"r\", encoding='utf-8') as f:\n",
     "    text_sequence = f.read()\n",
     "\n",
     "encoded_text_sequence = tokenizer.encode(text_sequence)\n",
@@ -383,7 +383,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "deep_learning",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -397,7 +397,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Explicitly added `encoding='utf-8'` to file open() call in `notebooks/4_1_ModelTrainingAllBatches.ipynb`  

On some systems (ex: Windows), the default file encoding is not UTF-8. This causes `UnicodeDecodeError` when the file contains non-ASCII characters. 

This change ensures the file is read correctly.